### PR TITLE
label方法switch条件拼写错误

### DIFF
--- a/Core/Func/CoreFunc.class.php
+++ b/Core/Func/CoreFunc.class.php
@@ -61,7 +61,7 @@ class CoreFunc {
             $totalDismantling = count($dismantling);
 
             if ($totalDismantling == 2) {
-                switch ($urlModel['URLMODE']) {
+                switch ($urlModel['URLMODEL']) {
                     case '2':
                         $url .= implode('-', $dismantling);
                         $url .= self::urlLinkStr($param, '-');


### PR DESCRIPTION
拼写错误导致在斜杠模式 隐藏index.php情况下，生成的URL无法访问
